### PR TITLE
Add option to not build Python runtime dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ When building the current repository, name of the branch/tag/SHA to build (defau
 
 URL of package to build (e.g., https://github.com/jobovy/galpy/archive/main.tar.gz); set either this or build-tag (neither defaults to current SHA)
 
+### `build-deps`
+
+Whether or not to build runtime Python dependencies (True/False; default: False). If you need a Python dependency during your build (e.g., `numpy`), then you'll have to run with `build-deps: True`.
+
 ## Advanced examples
 
 ### Custom ``meta.yaml`` location
@@ -81,4 +85,13 @@ E.g., to use the latest `main` branch
       with:
         package-name: galpy
         build-url: https://github.com/jobovy/galpy/archive/main.tar.gz
+```
+
+### Build all dependencies of your package
+
+```
+    - uses: jobovy/pyodide-buildpackage-action@main
+      with:
+        meta-yaml-path: .github/pyodide_meta.yaml
+        build-deps: True
 ```

--- a/action.yml
+++ b/action.yml
@@ -30,9 +30,9 @@ inputs:
     required: false
     default: "None"    
   build-deps:
-    description: "Whether or not to build runtime dependencies (True/False)"
+    description: "Whether or not to build runtime Python dependencies (True/False)"
     required: false
-    default: "True"    
+    default: "True" 
 runs:
   using: "docker"
   image: Dockerfile

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
   build-deps:
     description: "Whether or not to build runtime Python dependencies (True/False)"
     required: false
-    default: "True" 
+    default: "False" 
 runs:
   using: "docker"
   image: Dockerfile

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: "URL of package to build (e.g., https://github.com/jobovy/galpy/archive/main.tar.gz); set either this or build-tag (neither defaults to current SHA)"
     required: false
     default: "None"    
+  build-deps:
+    description: "Whether or not to build runtime dependencies (True/False)"
+    required: false
+    default: "True"    
 runs:
   using: "docker"
   image: Dockerfile
@@ -40,3 +44,4 @@ runs:
       - ${{ inputs.build-tag }}
       - ${{ inputs.build-url }}
       - ${{ inputs.all-wheels-output-dir }}
+      - ${{ inputs.build-deps }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,29 @@ else
     PACKAGE_URL=https://github.com/$GITHUB_REPOSITORY/archive/$5.tar.gz
 fi
 ALL_WHEELS_OUTPUT_DIR=`realpath $7`
+BUILD_DEPS=$8
+
+
+# Put meta.yaml in place
+mkdir -v -p packages/$PACKAGE_NAME
+cp -v $META_YAML_PATH packages/$PACKAGE_NAME/meta.yaml
+# Need to download to compute the checksum, required when using url
+wget -v $PACKAGE_URL -O packages/$PACKAGE_NAME/package.tar.gz
+CHECKSUM=`sha256sum packages/$PACKAGE_NAME/package.tar.gz | awk '{ print $1 }'`
+# Edit meta.yaml
+sed --debug -i 's@.*url:.*@  url: '"$PACKAGE_URL"'@' packages/$PACKAGE_NAME/meta.yaml
+sed --debug -i 's@.*sha256:.*@  sha256: '"$CHECKSUM"'@' packages/$PACKAGE_NAME/meta.yaml
+sed --debug -i '/md5:/d' packages/$PACKAGE_NAME/meta.yaml
+if [ "$8" = "False" ];
+    then
+         export PACKAGE_NAME
+         python -c "import os; PACKAGE_NAME=os.environ['PACKAGE_NAME']; from pathlib import Path; from ruamel.yaml import YAML; yaml= YAML(); f= yaml.load(Path(f'packages/{PACKAGE_NAME}/meta.yaml')); del f['requirements']; yaml.dump(f,Path(f'packages/{PACKAGE_NAME}/meta_e.yaml'))"
+         npx prettier -w packages/$PACKAGE_NAME/meta_e.yaml
+         mv packages/$PACKAGE_NAME/meta_e.yaml packages/$PACKAGE_NAME/meta.yaml
+    fi;
+cat packages/$PACKAGE_NAME/meta.yaml
+
+
 
 # Get pyodide and setup pyodide tools
 git clone https://github.com/pyodide/pyodide
@@ -36,6 +59,13 @@ CHECKSUM=`sha256sum packages/$PACKAGE_NAME/package.tar.gz | awk '{ print $1 }'`
 sed --debug -i 's@.*url:.*@  url: '"$PACKAGE_URL"'@' packages/$PACKAGE_NAME/meta.yaml
 sed --debug -i 's@.*sha256:.*@  sha256: '"$CHECKSUM"'@' packages/$PACKAGE_NAME/meta.yaml
 sed --debug -i '/md5:/d' packages/$PACKAGE_NAME/meta.yaml
+if [ "$8" = "False" ];
+    then
+         export PACKAGE_NAME
+         python -c "import os; PACKAGE_NAME=os.environ['PACKAGE_NAME']; from pathlib import Path; from ruamel.yaml import YAML; yaml= YAML(); f= yaml.load(Path(f'packages/{PACKAGE_NAME}/meta.yaml')); del f['requirements']; yaml.dump(f,Path(f'packages/{PACKAGE_NAME}/meta_e.yaml'))"
+         npx prettier -w packages/$PACKAGE_NAME/meta_e.yaml
+         mv packages/$PACKAGE_NAME/meta_e.yaml packages/$PACKAGE_NAME/meta.yaml
+    fi;
 cat packages/$PACKAGE_NAME/meta.yaml
 
 # Build and copy output to output directory

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,27 +21,6 @@ fi
 ALL_WHEELS_OUTPUT_DIR=`realpath $7`
 BUILD_DEPS=$8
 
-
-# Put meta.yaml in place
-mkdir -v -p packages/$PACKAGE_NAME
-cp -v $META_YAML_PATH packages/$PACKAGE_NAME/meta.yaml
-# Need to download to compute the checksum, required when using url
-wget -v $PACKAGE_URL -O packages/$PACKAGE_NAME/package.tar.gz
-CHECKSUM=`sha256sum packages/$PACKAGE_NAME/package.tar.gz | awk '{ print $1 }'`
-# Edit meta.yaml
-sed --debug -i 's@.*url:.*@  url: '"$PACKAGE_URL"'@' packages/$PACKAGE_NAME/meta.yaml
-sed --debug -i 's@.*sha256:.*@  sha256: '"$CHECKSUM"'@' packages/$PACKAGE_NAME/meta.yaml
-sed --debug -i '/md5:/d' packages/$PACKAGE_NAME/meta.yaml
-if [ "$BUILD_DEPS" = "false" ];
-then
-    export PACKAGE_NAME
-    python -c "import os; PACKAGE_NAME=os.environ['PACKAGE_NAME']; from pathlib import Path; from ruamel.yaml import YAML; yaml= YAML(); f= yaml.load(Path(f'packages/{PACKAGE_NAME}/meta.yaml')); del f['requirements']; yaml.dump(f,Path(f'packages/{PACKAGE_NAME}/meta_e.yaml'))"
-    npx prettier -w packages/$PACKAGE_NAME/meta_e.yaml
-    mv packages/$PACKAGE_NAME/meta_e.yaml packages/$PACKAGE_NAME/meta.yaml
-fi;
-cat packages/$PACKAGE_NAME/meta.yaml
-
-
 # Get pyodide and setup pyodide tools
 git clone https://github.com/pyodide/pyodide
 cd pyodide

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,15 +32,14 @@ CHECKSUM=`sha256sum packages/$PACKAGE_NAME/package.tar.gz | awk '{ print $1 }'`
 sed --debug -i 's@.*url:.*@  url: '"$PACKAGE_URL"'@' packages/$PACKAGE_NAME/meta.yaml
 sed --debug -i 's@.*sha256:.*@  sha256: '"$CHECKSUM"'@' packages/$PACKAGE_NAME/meta.yaml
 sed --debug -i '/md5:/d' packages/$PACKAGE_NAME/meta.yaml
-if [ "$8" = "False" ];
-    then
-         export PACKAGE_NAME
-         python -c "import os; PACKAGE_NAME=os.environ['PACKAGE_NAME']; from pathlib import Path; from ruamel.yaml import YAML; yaml= YAML(); f= yaml.load(Path(f'packages/{PACKAGE_NAME}/meta.yaml')); del f['requirements']; yaml.dump(f,Path(f'packages/{PACKAGE_NAME}/meta_e.yaml'))"
-         npx prettier -w packages/$PACKAGE_NAME/meta_e.yaml
-         mv packages/$PACKAGE_NAME/meta_e.yaml packages/$PACKAGE_NAME/meta.yaml
-    fi;
+if [ "$BUILD_DEPS" = "False" ];
+then
+    export PACKAGE_NAME
+    python -c "import os; PACKAGE_NAME=os.environ['PACKAGE_NAME']; from pathlib import Path; from ruamel.yaml import YAML; yaml= YAML(); f= yaml.load(Path(f'packages/{PACKAGE_NAME}/meta.yaml')); del f['requirements']; yaml.dump(f,Path(f'packages/{PACKAGE_NAME}/meta_e.yaml'))"
+    npx prettier -w packages/$PACKAGE_NAME/meta_e.yaml
+    mv packages/$PACKAGE_NAME/meta_e.yaml packages/$PACKAGE_NAME/meta.yaml
+fi;
 cat packages/$PACKAGE_NAME/meta.yaml
-
 
 
 # Get pyodide and setup pyodide tools
@@ -59,13 +58,13 @@ CHECKSUM=`sha256sum packages/$PACKAGE_NAME/package.tar.gz | awk '{ print $1 }'`
 sed --debug -i 's@.*url:.*@  url: '"$PACKAGE_URL"'@' packages/$PACKAGE_NAME/meta.yaml
 sed --debug -i 's@.*sha256:.*@  sha256: '"$CHECKSUM"'@' packages/$PACKAGE_NAME/meta.yaml
 sed --debug -i '/md5:/d' packages/$PACKAGE_NAME/meta.yaml
-if [ "$8" = "False" ];
-    then
-         export PACKAGE_NAME
-         python -c "import os; PACKAGE_NAME=os.environ['PACKAGE_NAME']; from pathlib import Path; from ruamel.yaml import YAML; yaml= YAML(); f= yaml.load(Path(f'packages/{PACKAGE_NAME}/meta.yaml')); del f['requirements']; yaml.dump(f,Path(f'packages/{PACKAGE_NAME}/meta_e.yaml'))"
-         npx prettier -w packages/$PACKAGE_NAME/meta_e.yaml
-         mv packages/$PACKAGE_NAME/meta_e.yaml packages/$PACKAGE_NAME/meta.yaml
-    fi;
+if [ "$BUILD_DEPS" = "False" ];
+then
+    export PACKAGE_NAME
+    python -c "import os; PACKAGE_NAME=os.environ['PACKAGE_NAME']; from pathlib import Path; from ruamel.yaml import YAML; yaml= YAML(); f= yaml.load(Path(f'packages/{PACKAGE_NAME}/meta.yaml')); del f['requirements']; yaml.dump(f,Path(f'packages/{PACKAGE_NAME}/meta_e.yaml'))"
+    npx prettier -w packages/$PACKAGE_NAME/meta_e.yaml
+    mv packages/$PACKAGE_NAME/meta_e.yaml packages/$PACKAGE_NAME/meta.yaml
+fi;
 cat packages/$PACKAGE_NAME/meta.yaml
 
 # Build and copy output to output directory

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,36 @@ fi
 ALL_WHEELS_OUTPUT_DIR=`realpath $7`
 BUILD_DEPS=$8
 
+# Put meta.yaml in place
+mkdir -v -p packages/$PACKAGE_NAME
+cp -v $META_YAML_PATH packages/$PACKAGE_NAME/meta.yaml
+# Need to download to compute the checksum, required when using url
+wget -v $PACKAGE_URL -O packages/$PACKAGE_NAME/package.tar.gz
+CHECKSUM=`sha256sum packages/$PACKAGE_NAME/package.tar.gz | awk '{ print $1 }'`
+# Edit meta.yaml
+sed --debug -i 's@.*url:.*@  url: '"$PACKAGE_URL"'@' packages/$PACKAGE_NAME/meta.yaml
+sed --debug -i 's@.*sha256:.*@  sha256: '"$CHECKSUM"'@' packages/$PACKAGE_NAME/meta.yaml
+sed --debug -i '/md5:/d' packages/$PACKAGE_NAME/meta.yaml
+if [ "$BUILD_DEPS" = "false" ];
+then
+    export PACKAGE_NAME
+    python -c "import os
+PACKAGE_NAME=os.environ['PACKAGE_NAME']
+from pathlib import Path
+from ruamel.yaml import YAML
+yaml= YAML()
+f= yaml.load(Path(f'packages/{PACKAGE_NAME}/meta.yaml'))
+if 'requirements' in f:
+    if 'run' in f['requirements']:
+        for ii in range(len(f['requirements']['run']))[::-1]:
+           if not f['requirements']['run'][ii].startswith('lib'):
+               del f['requirements']['run'][ii]
+yaml.dump(f,Path(f'packages/{PACKAGE_NAME}/meta_e.yaml'))"
+    npx prettier -w packages/$PACKAGE_NAME/meta_e.yaml
+    mv packages/$PACKAGE_NAME/meta_e.yaml packages/$PACKAGE_NAME/meta.yaml
+fi;
+cat packages/$PACKAGE_NAME/meta.yaml
+
 # Get pyodide and setup pyodide tools
 git clone https://github.com/pyodide/pyodide
 cd pyodide
@@ -40,7 +70,18 @@ sed --debug -i '/md5:/d' packages/$PACKAGE_NAME/meta.yaml
 if [ "$BUILD_DEPS" = "false" ];
 then
     export PACKAGE_NAME
-    python -c "import os; PACKAGE_NAME=os.environ['PACKAGE_NAME']; from pathlib import Path; from ruamel.yaml import YAML; yaml= YAML(); f= yaml.load(Path(f'packages/{PACKAGE_NAME}/meta.yaml')); del f['requirements']; yaml.dump(f,Path(f'packages/{PACKAGE_NAME}/meta_e.yaml'))"
+    python -c "import os
+PACKAGE_NAME=os.environ['PACKAGE_NAME']
+from pathlib import Path
+from ruamel.yaml import YAML
+yaml= YAML()
+f= yaml.load(Path(f'packages/{PACKAGE_NAME}/meta.yaml'))
+if 'requirements' in f:
+    if 'run' in f['requirements']:
+        for ii in range(len(f['requirements']['run']))[::-1]:
+           if not f['requirements']['run'][ii].startswith('lib'):
+               del f['requirements']['run'][ii]
+yaml.dump(f,Path(f'packages/{PACKAGE_NAME}/meta_e.yaml'))"
     npx prettier -w packages/$PACKAGE_NAME/meta_e.yaml
     mv packages/$PACKAGE_NAME/meta_e.yaml packages/$PACKAGE_NAME/meta.yaml
 fi;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,6 +69,10 @@ cat packages/$PACKAGE_NAME/meta.yaml
 
 # Build and copy output to output directory
 python -m pyodide_build buildall --only "$PACKAGE_NAME" packages $ALL_WHEELS_OUTPUT_DIR
+echo "Build log"
+cat packages/$PACKAGE_NAME/build.log
+
+# Copy wheel to output dir
 mkdir -v -p $OUTPUT_DIR
 cp -v $ALL_WHEELS_OUTPUT_DIR/*$PACKAGE_NAME* $OUTPUT_DIR
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,6 +37,7 @@ CHECKSUM=`sha256sum packages/$PACKAGE_NAME/package.tar.gz | awk '{ print $1 }'`
 sed --debug -i 's@.*url:.*@  url: '"$PACKAGE_URL"'@' packages/$PACKAGE_NAME/meta.yaml
 sed --debug -i 's@.*sha256:.*@  sha256: '"$CHECKSUM"'@' packages/$PACKAGE_NAME/meta.yaml
 sed --debug -i '/md5:/d' packages/$PACKAGE_NAME/meta.yaml
+# Need to move this to a file...
 if [ "$BUILD_DEPS" = "false" ];
 then
     export PACKAGE_NAME
@@ -45,11 +46,20 @@ PACKAGE_NAME=os.environ['PACKAGE_NAME']
 from pathlib import Path
 from ruamel.yaml import YAML
 yaml= YAML()
+def is_library(pkg):
+    f= yaml.load(Path(f'packages/{pkg}/meta.yaml'))
+    if not 'build' in f:
+        return False
+    if ('library' in f['build'] and f['build']['library']) \
+        or ('sharedlibrary' in f['build'] and f['build']['sharedlibrary']):
+        return True
+    else:
+        return False
 f= yaml.load(Path(f'packages/{PACKAGE_NAME}/meta.yaml'))
 if 'requirements' in f:
     if 'run' in f['requirements']:
         for ii in range(len(f['requirements']['run']))[::-1]:
-           if not f['requirements']['run'][ii].startswith('lib'):
+           if not is_library(f['requirements']['run'][ii]):
                del f['requirements']['run'][ii]
 yaml.dump(f,Path(f'packages/{PACKAGE_NAME}/meta_e.yaml'))"
     npx prettier -w packages/$PACKAGE_NAME/meta_e.yaml

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,7 @@ CHECKSUM=`sha256sum packages/$PACKAGE_NAME/package.tar.gz | awk '{ print $1 }'`
 sed --debug -i 's@.*url:.*@  url: '"$PACKAGE_URL"'@' packages/$PACKAGE_NAME/meta.yaml
 sed --debug -i 's@.*sha256:.*@  sha256: '"$CHECKSUM"'@' packages/$PACKAGE_NAME/meta.yaml
 sed --debug -i '/md5:/d' packages/$PACKAGE_NAME/meta.yaml
-if [ "$BUILD_DEPS" = "False" ];
+if [ "$BUILD_DEPS" = "false" ];
 then
     export PACKAGE_NAME
     python -c "import os; PACKAGE_NAME=os.environ['PACKAGE_NAME']; from pathlib import Path; from ruamel.yaml import YAML; yaml= YAML(); f= yaml.load(Path(f'packages/{PACKAGE_NAME}/meta.yaml')); del f['requirements']; yaml.dump(f,Path(f'packages/{PACKAGE_NAME}/meta_e.yaml'))"
@@ -58,7 +58,7 @@ CHECKSUM=`sha256sum packages/$PACKAGE_NAME/package.tar.gz | awk '{ print $1 }'`
 sed --debug -i 's@.*url:.*@  url: '"$PACKAGE_URL"'@' packages/$PACKAGE_NAME/meta.yaml
 sed --debug -i 's@.*sha256:.*@  sha256: '"$CHECKSUM"'@' packages/$PACKAGE_NAME/meta.yaml
 sed --debug -i '/md5:/d' packages/$PACKAGE_NAME/meta.yaml
-if [ "$BUILD_DEPS" = "False" ];
+if [ "$BUILD_DEPS" = "false" ];
 then
     export PACKAGE_NAME
     python -c "import os; PACKAGE_NAME=os.environ['PACKAGE_NAME']; from pathlib import Path; from ruamel.yaml import YAML; yaml= YAML(); f= yaml.load(Path(f'packages/{PACKAGE_NAME}/meta.yaml')); del f['requirements']; yaml.dump(f,Path(f'packages/{PACKAGE_NAME}/meta_e.yaml'))"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,36 +21,6 @@ fi
 ALL_WHEELS_OUTPUT_DIR=`realpath $7`
 BUILD_DEPS=$8
 
-# Put meta.yaml in place
-mkdir -v -p packages/$PACKAGE_NAME
-cp -v $META_YAML_PATH packages/$PACKAGE_NAME/meta.yaml
-# Need to download to compute the checksum, required when using url
-wget -v $PACKAGE_URL -O packages/$PACKAGE_NAME/package.tar.gz
-CHECKSUM=`sha256sum packages/$PACKAGE_NAME/package.tar.gz | awk '{ print $1 }'`
-# Edit meta.yaml
-sed --debug -i 's@.*url:.*@  url: '"$PACKAGE_URL"'@' packages/$PACKAGE_NAME/meta.yaml
-sed --debug -i 's@.*sha256:.*@  sha256: '"$CHECKSUM"'@' packages/$PACKAGE_NAME/meta.yaml
-sed --debug -i '/md5:/d' packages/$PACKAGE_NAME/meta.yaml
-if [ "$BUILD_DEPS" = "false" ];
-then
-    export PACKAGE_NAME
-    python -c "import os
-PACKAGE_NAME=os.environ['PACKAGE_NAME']
-from pathlib import Path
-from ruamel.yaml import YAML
-yaml= YAML()
-f= yaml.load(Path(f'packages/{PACKAGE_NAME}/meta.yaml'))
-if 'requirements' in f:
-    if 'run' in f['requirements']:
-        for ii in range(len(f['requirements']['run']))[::-1]:
-           if not f['requirements']['run'][ii].startswith('lib'):
-               del f['requirements']['run'][ii]
-yaml.dump(f,Path(f'packages/{PACKAGE_NAME}/meta_e.yaml'))"
-    npx prettier -w packages/$PACKAGE_NAME/meta_e.yaml
-    mv packages/$PACKAGE_NAME/meta_e.yaml packages/$PACKAGE_NAME/meta.yaml
-fi;
-cat packages/$PACKAGE_NAME/meta.yaml
-
 # Get pyodide and setup pyodide tools
 git clone https://github.com/pyodide/pyodide
 cd pyodide


### PR DESCRIPTION
But does build `library/sharedlibrary` dependencies. Not clever enough to figure out that you need, e.g., `numpy` for your install, in that case you'll just have to run with building all dependencies. Not building dependencies is the default.